### PR TITLE
v2016R SCC anomaly fix

### DIFF
--- a/src/2016R.jl
+++ b/src/2016R.jl
@@ -326,7 +326,7 @@ function model_eqs(model::Model, config::OptionsV2016, params::ParametersV2016, 
     @NLconstraint(model, [i=1:N-1], vars.RI[i] == (1+config.ρ)*(vars.CPC[i+1]/vars.CPC[i])^(config.α/config.tstep)-1);
 
     # Savings rate for asympotic equilibrium
-    @constraint(model, vars.S[N-10:N] .== params.optlrsav);
+    @constraint(model, vars.S[N-9:N] .== params.optlrsav);
     # Initial conditions
     @constraint(model, vars.CCA[1] == 400.0);
     @NLconstraint(model, vars.K[1] == config.k₀);

--- a/src/CJL.jl
+++ b/src/CJL.jl
@@ -362,7 +362,7 @@ function model_results(model::Model, config::OptionsVCJL, params::ParametersVCJL
     S = value.(vars.S);
     μ = value.(vars.μ);
     RI = value.(vars.RI);
-    scc = -1000 .* shadow_price.(eqs.eeq)./(shadow_price.(eqs.kk) .+ 0.00000000001);
+    scc = 1000 .* shadow_price.(eqs.eeq)./(shadow_price.(eqs.kk) .+ 0.00000000001);
     mcemis = config.θ₂.*params.θ₁.*μ.^(config.θ₂-1)./params.σ.*1000.;
     ResultsVCJL(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,
                Y,E,I,K,MPK,C,CPC,PERIODU,UTILITY,S,μ,RI,scc,MCABATE,MₐₜAV,PCY,mcemis)

--- a/src/CJL.jl
+++ b/src/CJL.jl
@@ -362,7 +362,7 @@ function model_results(model::Model, config::OptionsVCJL, params::ParametersVCJL
     S = value.(vars.S);
     μ = value.(vars.μ);
     RI = value.(vars.RI);
-    scc = -1000 .* dual.(eqs.eeq)./(dual.(eqs.kk) .+ 0.00000000001);
+    scc = -1000 .* shadow_price.(eqs.eeq)./(shadow_price.(eqs.kk) .+ 0.00000000001);
     mcemis = config.θ₂.*params.θ₁.*μ.^(config.θ₂-1)./params.σ.*1000.;
     ResultsVCJL(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,
                Y,E,I,K,MPK,C,CPC,PERIODU,UTILITY,S,μ,RI,scc,MCABATE,MₐₜAV,PCY,mcemis)

--- a/src/Results2013R.jl
+++ b/src/Results2013R.jl
@@ -52,9 +52,9 @@ function model_results(model::Model, config::Options, params::Parameters, vars::
     RI = value.(vars.RI);
     CEMUTOTPER = value.(vars.CEMUTOTPER);
     scc = if typeof(eqs) <: VanillaEquations
-        -1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.cc)
+        1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.cc)
     else
-        -1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.yy)
+        1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.yy)
     end;
     ResultsV2013(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,
                Y,E,I,K,MPK,C,CPC,PERIODU,UTILITY,S,μ,RI,scc,Eind,Σ,Ω,Λ,co2price,cprice,μ_participants,MCABATE,co2price_avg,CEMUTOTPER)

--- a/src/Results2013R.jl
+++ b/src/Results2013R.jl
@@ -52,9 +52,9 @@ function model_results(model::Model, config::Options, params::Parameters, vars::
     RI = value.(vars.RI);
     CEMUTOTPER = value.(vars.CEMUTOTPER);
     scc = if typeof(eqs) <: VanillaEquations
-        -1000 .* dual.(eqs.eeq)./dual.(eqs.cc)
+        -1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.cc)
     else
-        -1000 .* dual.(eqs.eeq)./dual.(eqs.yy)
+        -1000 .* shadow_price.(eqs.eeq)./shadow_price.(eqs.yy)
     end;
     ResultsV2013(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,
                Y,E,I,K,MPK,C,CPC,PERIODU,UTILITY,S,μ,RI,scc,Eind,Σ,Ω,Λ,co2price,cprice,μ_participants,MCABATE,co2price_avg,CEMUTOTPER)

--- a/src/Results2016R.jl
+++ b/src/Results2016R.jl
@@ -45,7 +45,7 @@ function model_results(model::JuMP.Model, config::OptionsV2016, params::Paramete
     μ = value.(vars.μ);
     μ_participants = (co2price./params.pbacktime).^(1/(config.θ₂-1));
     RI = value.(vars.RI);
-    scc = -1000 .* dual.(eqs.eeq)./(.00001 .+ dual.(eqs.cc));
+    scc = -1000 .* shadow_price.(eqs.eeq)./(.00001 .+ shadow_price.(eqs.cc));
     atfrac = (Mₐₜ .- 588)./(CCATOT .+ .000001);
     atfrac2010 = (Mₐₜ .- config.mat₀)./(.00001 .+ CCATOT .- CCATOT[1]);
     ResultsV2016(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,

--- a/src/Results2016R.jl
+++ b/src/Results2016R.jl
@@ -45,7 +45,7 @@ function model_results(model::JuMP.Model, config::OptionsV2016, params::Paramete
     μ = value.(vars.μ);
     μ_participants = (co2price./params.pbacktime).^(1/(config.θ₂-1));
     RI = value.(vars.RI);
-    scc = -1000 .* shadow_price.(eqs.eeq)./(.00001 .+ shadow_price.(eqs.cc));
+    scc = 1000 .* shadow_price.(eqs.eeq)./(.00001 .+ shadow_price.(eqs.cc));
     atfrac = (Mₐₜ .- 588)./(CCATOT .+ .000001);
     atfrac2010 = (Mₐₜ .- config.mat₀)./(.00001 .+ CCATOT .- CCATOT[1]);
     ResultsV2016(years,Mₐₜ,Mₐₜppm,Mᵤₚ,Mₗₒ,CCA,CCAratio,Tₐₜ,FORC,Tₗₒ,YGROSS,DAMAGES,YNET,


### PR DESCRIPTION
There's a large anomaly in the v2016R SCC for both scenarios.

We start with fixing the Savings rate offset, that aligns both `S` and `K` back to the GAMS result. Closes #25.